### PR TITLE
Use Spans for list items to wrap text after bullets

### DIFF
--- a/bypass/src/main/java/in/uncod/android/bypass/Bypass.java
+++ b/bypass/src/main/java/in/uncod/android/bypass/Bypass.java
@@ -28,6 +28,7 @@ import in.uncod.android.bypass.Element.Type;
 import in.uncod.android.bypass.style.CharacterIndentSpan;
 import in.uncod.android.bypass.style.HorizontalLineSpan;
 import in.uncod.android.bypass.style.NumberIndentSpan;
+import in.uncod.android.bypass.style.ParagraphSpacingSpan;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,6 +41,7 @@ public class Bypass {
     private final Options mOptions;
 
     private final int mListItemIndent;
+    private final int mListItemBottomSpace;
     private final int mBlockQuoteIndent;
     private final int mCodeBlockIndent;
     private final int mHruleSize;
@@ -62,6 +64,9 @@ public class Bypass {
 
         mListItemIndent = (int) TypedValue.applyDimension(mOptions.mListItemIndentUnit,
                 mOptions.mListItemIndentSize, dm);
+
+        mListItemBottomSpace = (int) TypedValue.applyDimension(mOptions.mListItemBottomSpaceUnit,
+                mOptions.mListItemBottomSpaceSize, dm);
 
         mBlockQuoteIndent = (int) TypedValue.applyDimension(mOptions.mBlockQuoteIndentUnit,
                 mOptions.mBlockQuoteIndentSize, dm);
@@ -228,6 +233,7 @@ public class Bypass {
                 } else {
                     setSpan(builder, new CharacterIndentSpan(mListItemIndent, mOptions.mUnorderedListItem));
                 }
+                setSpan(builder, new ParagraphSpacingSpan(mListItemBottomSpace));
                 break;
             case EMPHASIS:
                 setSpan(builder, new StyleSpan(Typeface.ITALIC));
@@ -313,6 +319,9 @@ public class Bypass {
         private int mListItemIndentUnit;
         private float mListItemIndentSize;
 
+        private int mListItemBottomSpaceUnit;
+        private float mListItemBottomSpaceSize;
+
         private int mBlockQuoteColor;
         private int mBlockQuoteIndentUnit;
         private float mBlockQuoteIndentSize;
@@ -337,6 +346,9 @@ public class Bypass {
             mUnorderedListItem = "\u2022";
             mListItemIndentUnit = TypedValue.COMPLEX_UNIT_DIP;
             mListItemIndentSize = 20;
+
+            mListItemBottomSpaceUnit = TypedValue.COMPLEX_UNIT_DIP;
+            mListItemBottomSpaceSize = 5;
 
             mBlockQuoteColor = 0xff0000ff;
             mBlockQuoteIndentUnit = TypedValue.COMPLEX_UNIT_DIP;

--- a/bypass/src/main/java/in/uncod/android/bypass/Bypass.java
+++ b/bypass/src/main/java/in/uncod/android/bypass/Bypass.java
@@ -25,7 +25,9 @@ import android.util.TypedValue;
 import android.view.View;
 
 import in.uncod.android.bypass.Element.Type;
+import in.uncod.android.bypass.style.CharacterIndentSpan;
 import in.uncod.android.bypass.style.HorizontalLineSpan;
+import in.uncod.android.bypass.style.NumberIndentSpan;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -157,17 +159,6 @@ public class Bypass {
             case LINEBREAK:
                 builder.append("\n");
                 break;
-            case LIST_ITEM:
-                builder.append(" ");
-                if (mOrderedListNumber.containsKey(element.getParent())) {
-                    int number = mOrderedListNumber.get(element.getParent());
-                    builder.append(Integer.toString(number) + ".");
-                    mOrderedListNumber.put(element.getParent(), number + 1);
-                } else {
-                    builder.append(mOptions.mUnorderedListItem);
-                }
-                builder.append("  ");
-                break;
             case AUTOLINK:
                 builder.append(element.getAttribute("link"));
                 break;
@@ -229,8 +220,14 @@ public class Bypass {
                 setSpan(builder, new RelativeSizeSpan(mOptions.mHeaderSizes[level - 1]));
                 setSpan(builder, new StyleSpan(Typeface.BOLD));
                 break;
-            case LIST:
-                setBlockSpan(builder, new LeadingMarginSpan.Standard(mListItemIndent));
+            case LIST_ITEM:
+                if (mOrderedListNumber.containsKey(element.getParent())) {
+                    int number = mOrderedListNumber.get(element.getParent());
+                    mOrderedListNumber.put(element.getParent(), number + 1);
+                    setSpan(builder, new NumberIndentSpan(mListItemIndent, number));
+                } else {
+                    setSpan(builder, new CharacterIndentSpan(mListItemIndent, mOptions.mUnorderedListItem));
+                }
                 break;
             case EMPHASIS:
                 setSpan(builder, new StyleSpan(Typeface.ITALIC));
@@ -339,7 +336,7 @@ public class Bypass {
 
             mUnorderedListItem = "\u2022";
             mListItemIndentUnit = TypedValue.COMPLEX_UNIT_DIP;
-            mListItemIndentSize = 10;
+            mListItemIndentSize = 20;
 
             mBlockQuoteColor = 0xff0000ff;
             mBlockQuoteIndentUnit = TypedValue.COMPLEX_UNIT_DIP;

--- a/bypass/src/main/java/in/uncod/android/bypass/style/CharacterIndentSpan.java
+++ b/bypass/src/main/java/in/uncod/android/bypass/style/CharacterIndentSpan.java
@@ -1,0 +1,33 @@
+package in.uncod.android.bypass.style;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.text.Layout;
+import android.text.style.LeadingMarginSpan;
+
+public class CharacterIndentSpan implements LeadingMarginSpan {
+
+    private final int leadWidth;
+    private final String character;
+
+    public CharacterIndentSpan(int leadGap, String character) {
+        this.leadWidth = leadGap;
+        this.character = character;
+    }
+
+    public int getLeadingMargin(boolean first) {
+        return leadWidth;
+    }
+
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top,
+                                  int baseline, int bottom, CharSequence text, int start, int end,
+                                  boolean first, Layout l) {
+        if (first) {
+            Paint.Style orgStyle = p.getStyle();
+            p.setStyle(Paint.Style.FILL);
+            float width = p.measureText(character + " ");
+            c.drawText(character, (x + (leadWidth-width)) * dir, baseline, p);
+            p.setStyle(orgStyle);
+        }
+    }
+}

--- a/bypass/src/main/java/in/uncod/android/bypass/style/NumberIndentSpan.java
+++ b/bypass/src/main/java/in/uncod/android/bypass/style/NumberIndentSpan.java
@@ -1,0 +1,33 @@
+package in.uncod.android.bypass.style;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.text.Layout;
+import android.text.style.LeadingMarginSpan;
+
+public class NumberIndentSpan implements LeadingMarginSpan {
+
+    private final int leadWidth;
+    private final int index;
+
+    public NumberIndentSpan(int leadGap, int index) {
+        this.leadWidth = leadGap;
+        this.index = index;
+    }
+
+    public int getLeadingMargin(boolean first) {
+        return leadWidth;
+    }
+
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top,
+                                  int baseline, int bottom, CharSequence text, int start, int end,
+                                  boolean first, Layout l) {
+        if (first) {
+            Paint.Style orgStyle = p.getStyle();
+            p.setStyle(Paint.Style.FILL);
+            float width = p.measureText("5. ");
+            c.drawText(index + ".", (x + (leadWidth-width)) * dir, baseline, p);
+            p.setStyle(orgStyle);
+        }
+    }
+}

--- a/bypass/src/main/java/in/uncod/android/bypass/style/ParagraphSpacingSpan.java
+++ b/bypass/src/main/java/in/uncod/android/bypass/style/ParagraphSpacingSpan.java
@@ -1,0 +1,26 @@
+package in.uncod.android.bypass.style;
+
+import android.graphics.Paint;
+import android.text.Spanned;
+import android.text.style.LineHeightSpan;
+
+public class ParagraphSpacingSpan implements LineHeightSpan {
+
+    private final int bottomSpacing;
+
+    public ParagraphSpacingSpan(int bottomSpacing){
+        this.bottomSpacing = bottomSpacing;
+    }
+
+    @Override
+    public void chooseHeight(CharSequence text, int start, int end,
+                             int spanstartv, int v, Paint.FontMetricsInt fm) {
+        Spanned spanned = (Spanned) text;
+        int st = spanned.getSpanStart(this);
+        int en = spanned.getSpanEnd(this);
+        if (end == en) {
+            fm.descent += bottomSpacing;
+            fm.bottom += bottomSpacing;
+        }
+    }
+}


### PR DESCRIPTION
Hi, I've created some LeadingMarginSpans so that multiline list items indent to after the bullet point. Should I make this PR here or against the main library? 

<img width="454" alt="screen shot 2017-03-24 at 2 33 49 pm" src="https://cloud.githubusercontent.com/assets/2576935/24314526/453bacf8-109f-11e7-800c-0000c0bbe5b6.png">
